### PR TITLE
Add currency code to transaction event

### DIFF
--- a/src/services/Commerce.php
+++ b/src/services/Commerce.php
@@ -146,6 +146,7 @@ class Commerce extends Component
         if ($order && $analytics) {
             // First, include the transaction data
             $analytics->setTransactionId($order->number)
+                ->setCurrencyCode($order->paymentCurrency)
                 ->setRevenue($order->totalPrice)
                 ->setTax($order->getAdjustmentsTotalByType('tax', true))
                 ->setShipping($order->getAdjustmentsTotalByType('shipping', true));


### PR DESCRIPTION
I've added the `setCurrencyCode()` method to the `addCommerceOrderToAnalytics` event.
This is useful for sites that support multiple currencies at checkout.

In Google Analytics the orders revenue will be converted to the base currency for that account.