### PR TITLE
Verify if purchasable exists before getting its title

### DIFF
--- a/src/services/Commerce.php
+++ b/src/services/Commerce.php
@@ -187,7 +187,7 @@ class Commerce extends Component
             //This is the same for both variant and non variant products
             $productData = [
                 'name' => $purchasable->title ?? $lineItem->description,
-                'sku' => $purchasable->sku,
+                'sku' => $purchasable->sku ?? $lineItem->sku,
                 'price' => $lineItem->salePrice,
                 'quantity' => $lineItem->qty,
             ];

--- a/src/services/Commerce.php
+++ b/src/services/Commerce.php
@@ -109,7 +109,7 @@ class Commerce extends Component
         $order = null, $lineItem = null
     ) {
         if ($lineItem) {
-            $title = $lineItem->purchasable->title;
+            $title = $lineItem->purchasable->title ?? $lineItem->description;
             $quantity = $lineItem->qty;
             $analytics = InstantAnalytics::$plugin->ia->eventAnalytics(
                 'Commerce',


### PR DESCRIPTION
### Description

Currently, if a user removes an LineItem without purchasable from the cart, it throws an error. Adding this check will prevent this issue.

### Related issues

None