### PR TITLE
Fix property types in the addCommerceProductDetaIlView()

### DIFF
--- a/src/helpers/IAnalytics.php
+++ b/src/helpers/IAnalytics.php
@@ -12,6 +12,8 @@
 namespace nystudio107\instantanalytics\helpers;
 
 use Craft;
+use craft\commerce\elements\Product;
+use craft\commerce\elements\Variant;
 use Exception;
 use nystudio107\instantanalytics\InstantAnalytics;
 use TheIconic\Tracking\GoogleAnalytics\Analytics;
@@ -88,9 +90,9 @@ class IAnalytics extends Analytics
     /**
      * Add a product detail view to the Analytics object
      *
-     * @param ?string $productVariant
+     * @param null|Product|Variant $productVariant
      */
-    public function addCommerceProductDetailView(?string $productVariant = null): void
+    public function addCommerceProductDetailView(null|Product|Variant $productVariant = null): void
     {
         if (InstantAnalytics::$commercePlugin) {
             if ($productVariant) {


### PR DESCRIPTION
### Description
`nystudio107\instantanalytics\services\addCommerceProductDetailView()`
 Expects a product or variant element, but here we only pass a string or null, which breaks the whole logic.
I fixed the types for the argument.

In the 3rd version there is was no strict type for the argument

### Related issues
https://github.com/nystudio107/craft-instantanalytics/issues/75